### PR TITLE
Add settings tab to configure shadows

### DIFF
--- a/apps/openmw/mwgui/settingswindow.cpp
+++ b/apps/openmw/mwgui/settingswindow.cpp
@@ -184,6 +184,8 @@ namespace MWGui
         getWidget(mKeyboardSwitch, "KeyboardButton");
         getWidget(mControllerSwitch, "ControllerButton");
         getWidget(mWaterTextureSize, "WaterTextureSize");
+        getWidget(mShadowTextureSize, "ShadowsTextureSize");
+        getWidget(mNumberOfShadowMaps, "NumberOfShadowMaps");
 
 #ifndef WIN32
         // hide gamma controls since it currently does not work under Linux
@@ -207,6 +209,9 @@ namespace MWGui
         mResolutionList->eventListChangePosition += MyGUI::newDelegate(this, &SettingsWindow::onResolutionSelected);
 
         mWaterTextureSize->eventComboChangePosition += MyGUI::newDelegate(this, &SettingsWindow::onWaterTextureSizeChanged);
+
+        mShadowTextureSize->eventComboChangePosition += MyGUI::newDelegate(this, &SettingsWindow::onShadowTextureSizeChanged);
+        mNumberOfShadowMaps->eventComboChangePosition += MyGUI::newDelegate(this, &SettingsWindow::onNumberOfShadowMapsChanged);
 
         mKeyboardSwitch->eventMouseButtonClick += MyGUI::newDelegate(this, &SettingsWindow::onKeyboardSwitchClicked);
         mControllerSwitch->eventMouseButtonClick += MyGUI::newDelegate(this, &SettingsWindow::onControllerSwitchClicked);
@@ -247,6 +252,19 @@ namespace MWGui
             mWaterTextureSize->setIndexSelected(1);
         if (waterTextureSize >= 2048)
             mWaterTextureSize->setIndexSelected(2);
+
+        int shadowsTextureSize = Settings::Manager::getInt ("shadow map resolution", "Shadows");
+        if (shadowsTextureSize >= 1024)
+            mShadowTextureSize->setIndexSelected(0);
+        if (shadowsTextureSize >= 2048)
+            mShadowTextureSize->setIndexSelected(1);
+        if (shadowsTextureSize >= 4096)
+            mShadowTextureSize->setIndexSelected(2);
+        if (shadowsTextureSize >= 8192)
+            mShadowTextureSize->setIndexSelected(3);
+
+        int numberOfShadowMaps = Settings::Manager::getInt ("number of shadow maps", "Shadows");
+        mNumberOfShadowMaps->setIndexSelected(numberOfShadowMaps-1);
 
         mWindowBorderButton->setEnabled(!Settings::Manager::getBool("fullscreen", "Video"));
 
@@ -324,6 +342,27 @@ namespace MWGui
         else if (pos == 2)
             size = 2048;
         Settings::Manager::setInt("rtt size", "Water", size);
+        apply();
+    }
+
+    void SettingsWindow::onShadowTextureSizeChanged(MyGUI::ComboBox* _sender, size_t pos)
+    {
+        int size = 0;
+        if (pos == 0)
+            size = 1024;
+        else if (pos == 1)
+            size = 2048;
+        else if (pos == 2)
+            size = 4096;
+        else if (pos == 3)
+            size = 8192;
+        Settings::Manager::setInt("shadow map resolution", "Shadows", size);
+        apply();
+    }
+
+    void SettingsWindow::onNumberOfShadowMapsChanged(MyGUI::ComboBox* _sender, size_t pos)
+    {
+        Settings::Manager::setInt("number of shadow maps", "Shadows", pos+1);
         apply();
     }
 

--- a/apps/openmw/mwgui/settingswindow.hpp
+++ b/apps/openmw/mwgui/settingswindow.hpp
@@ -34,6 +34,9 @@ namespace MWGui
 
             MyGUI::ComboBox* mWaterTextureSize;
 
+            MyGUI::ComboBox* mShadowTextureSize;
+            MyGUI::ComboBox* mNumberOfShadowMaps;
+
             // controls
             MyGUI::ScrollView* mControlsBox;
             MyGUI::Button* mResetControlsButton;
@@ -52,6 +55,9 @@ namespace MWGui
             void highlightCurrentResolution();
 
             void onWaterTextureSizeChanged(MyGUI::ComboBox* _sender, size_t pos);
+
+            void onShadowTextureSizeChanged(MyGUI::ComboBox* _sender, size_t pos);
+            void onNumberOfShadowMapsChanged(MyGUI::ComboBox* _sender, size_t pos);
 
             void onRebindAction(MyGUI::Widget* _sender);
             void onInputTabMouseWheel(MyGUI::Widget* _sender, int _rel);

--- a/apps/openmw/mwrender/renderingmanager.cpp
+++ b/apps/openmw/mwrender/renderingmanager.cpp
@@ -245,7 +245,7 @@ namespace MWRender
         int indoorShadowCastingTraversalMask = shadowCastingTraversalMask;
         if (Settings::Manager::getBool("object shadows", "Shadows"))
             shadowCastingTraversalMask |= Mask_Object;
-        
+
         mShadowManager.reset(new SceneUtil::ShadowManager(sceneRoot, mRootNode, shadowCastingTraversalMask, indoorShadowCastingTraversalMask, mResourceSystem->getSceneManager()->getShaderManager()));
 
         Shader::ShaderManager::DefineMap shadowDefines = mShadowManager->getShadowDefines();
@@ -1268,6 +1268,10 @@ namespace MWRender
                 updateTextureFiltering();
             else if (it->first == "Water")
                 mWater->processChangedSettings(changed);
+            else if (it->first == "Shadows")
+            {
+                // TODO: rebuild shadow scene here
+            }
         }
     }
 

--- a/files/mygui/openmw_settings_window.layout
+++ b/files/mygui/openmw_settings_window.layout
@@ -420,17 +420,13 @@
                                 </Widget>
                             </Widget>
                         </Widget>
-
                     </Widget>
-                    <!--
                     <Widget type="TabItem" skin="" position="0 28 352 268">
-                    <Widget type="Widget" skin="" position="0 28 352 268">
-                        <Property key="Visible" value="false"/>
                         <Property key="Caption" value="  Shadows  "/>
                         <Widget type="HBox" skin="" position="4 4 350 24">
                             <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top" name="ShadowsEnabledButton">
                                 <UserString key="SettingCategory" value="Shadows"/>
-                                <UserString key="SettingName" value="enabled"/>
+                                <UserString key="SettingName" value="enable shadows"/>
                                 <UserString key="SettingType" value="CheckButton"/>
                             </Widget>
                             <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 65 16" align="Left Top">
@@ -439,23 +435,23 @@
                         </Widget>
                         <Widget type="Widget" skin="" position="24 32 300 230">
                             <Widget type="HBox" skin="" position="4 0 350 24">
-                                <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top" name="ShadowsLargeDistance">
+                                <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top" name="ObjectShadows">
                                     <UserString key="SettingCategory" value="Shadows"/>
-                                    <UserString key="SettingName" value="split"/>
-                                    <UserString key="SettingType" value="CheckButton"/>
-                                </Widget>
-                                <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 182 16" align="Left Top">
-                                    <Property key="Caption" value="Large distance (PSSM3)"/>
-                                </Widget>
-                            </Widget>
-                            <Widget type="HBox" skin="" position="4 28 350 24">
-                                <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top" name="TerrainShadows">
-                                    <UserString key="SettingCategory" value="Shadows"/>
-                                    <UserString key="SettingName" value="terrain shadows"/>
+                                    <UserString key="SettingName" value="object shadows"/>
                                     <UserString key="SettingType" value="CheckButton"/>
                                 </Widget>
                                 <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 122 16" align="Left Top">
-                                    <Property key="Caption" value="Terrain shadows"/>
+                                    <Property key="Caption" value="Object shadows"/>
+                                </Widget>
+                            </Widget>
+                            <Widget type="HBox" skin="" position="4 28 350 24">
+                                <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top" name="PlayerShadows">
+                                    <UserString key="SettingCategory" value="Shadows"/>
+                                    <UserString key="SettingName" value="player shadows"/>
+                                    <UserString key="SettingType" value="CheckButton"/>
+                                </Widget>
+                                <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 122 16" align="Left Top">
+                                    <Property key="Caption" value="Player shadow"/>
                                 </Widget>
                             </Widget>
                             <Widget type="HBox" skin="" position="4 56 350 24">
@@ -469,39 +465,59 @@
                                 </Widget>
                             </Widget>
                             <Widget type="HBox" skin="" position="4 84 350 24">
-                                <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top" name="StaticsShadows">
+                                <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top" name="IndoorShadows">
                                     <UserString key="SettingCategory" value="Shadows"/>
-                                    <UserString key="SettingName" value="statics shadows"/>
+                                    <UserString key="SettingName" value="enable indoor shadows"/>
                                     <UserString key="SettingType" value="CheckButton"/>
                                 </Widget>
-                                <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 111 16" align="Left Top">
-                                    <Property key="Caption" value="World shadows"/>
+                                <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 108 16" align="Left Top">
+                                    <Property key="Caption" value="Indoor shadows"/>
                                 </Widget>
                             </Widget>
                             <Widget type="HBox" skin="" position="4 112 350 24">
-                                <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top" name="MiscShadows">
+                                <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top" name="ComputeBounds">
                                     <UserString key="SettingCategory" value="Shadows"/>
-                                    <UserString key="SettingName" value="misc shadows"/>
+                                    <UserString key="SettingName" value="compute tight scene bounds"/>
                                     <UserString key="SettingType" value="CheckButton"/>
                                 </Widget>
-                                <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 102 16" align="Left Top">
-                                    <Property key="Caption" value="Misc shadows"/>
+                                <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 108 16" align="Left Top">
+                                    <Property key="Caption" value="Compute tight scene bounds"/>
                                 </Widget>
                             </Widget>
                             <Widget type="HBox" skin="" position="4 140 350 24">
-                                <Widget type="ComboBox" skin="MW_ComboBox" position="0 0 60 24" align="Left Top" name="ShadowsTextureSize">
-                                    <Property key="AddItem" value="512"/>
+                                <Widget type="ComboBox" skin="MW_ComboBox" position="0 0 70 24" align="Left Top" name="ShadowsTextureSize">
                                     <Property key="AddItem" value="1024"/>
                                     <Property key="AddItem" value="2048"/>
                                     <Property key="AddItem" value="4096"/>
+                                    <Property key="AddItem" value="8192"/>
                                 </Widget>
                                 <Widget type="AutoSizedTextBox" skin="SandText" position="64 4 90 16" align="Left Top">
-                                    <Property key="Caption" value="Texture size"/>
+                                    <Property key="Caption" value="Shadow map resolution"/>
+                                </Widget>
+                            </Widget>
+                            <Widget type="HBox" skin="" position="4 168 350 24">
+                                <Widget type="ComboBox" skin="MW_ComboBox" position="0 0 50 24" align="Left Top" name="NumberOfShadowMaps">
+                                    <Property key="AddItem" value="1"/>
+                                    <Property key="AddItem" value="2"/>
+                                    <Property key="AddItem" value="3"/>
+                                    <Property key="AddItem" value="4"/>
+                                </Widget>
+                                <Widget type="AutoSizedTextBox" skin="SandText" position="64 4 90 16" align="Left Top">
+                                    <Property key="Caption" value="Number of shadow maps"/>
+                                </Widget>
+                            </Widget>
+                            <Widget type="HBox" skin="" position="4 196 350 24">
+                                <Widget type="AutoSizedButton" skin="MW_Button" position="0 0 24 24" align="Left Top" name="ShadowMapOverlapping">
+                                    <UserString key="SettingCategory" value="Shadows"/>
+                                    <UserString key="SettingName" value="allow shadow map overlap"/>
+                                    <UserString key="SettingType" value="CheckButton"/>
+                                </Widget>
+                                <Widget type="AutoSizedTextBox" skin="SandText" position="28 4 108 16" align="Left Top">
+                                    <Property key="Caption" value="Cascaded shadow maps"/>
                                 </Widget>
                             </Widget>
                         </Widget>
                     </Widget>
-                    -->
                 </Widget>
             </Widget>
         </Widget>


### PR DESCRIPTION
Just adds a "Shadows" tab to settings windows.

Notes:
1. I did not ad debug settings here and split ratios.
2. Terrain shadows have no button too since they conflict with Distant Terrain.
3. We still need to re-read settings in the renderingmanager.cpp on the fly, without game restart.